### PR TITLE
feat: bump the appsflyer sdk to version 6.14.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ playground.xcworkspace
 # Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
 Packages/
 Package.pins
-Package.resolved
 # *.xcodeproj
 #
 # Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,25 @@
 ## Version - 1.0.0 - 2022-07-06
+
 ### Added
+
 - Release version 1.0.0
 
 ## Version - 1.1.0 - 2023-06-12
+
 ### Added
+
 - Support for Swift Package Manager.
 
 ## Version - 1.1.1 - 2023-08-22
+
 ### Bug Fixes
+
 - Disabled destination is getting initialized.
+
+## Version - 1.2.0 - 2023-11-24
+
+### Bug Fixes
+
+- Bump the AppsFlyer SDK to the latest version 6.14.0.
+- Change the codeowner to @rudderlabs/sdk-ios.
+- Address asset validation issue.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-* @itsdebs
-* @pallabmaiti
+* @rudderlabs/sdk-ios

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,25 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "AppsFlyerLib",
+        "repositoryURL": "https://github.com/AppsFlyerSDK/AppsFlyerFramework-Static",
+        "state": {
+          "branch": null,
+          "revision": "19c1c5c476d431e381f35c8c99a2fe6435085207",
+          "version": "6.14.0"
+        }
+      },
+      {
+        "package": "Rudder",
+        "repositoryURL": "https://github.com/rudderlabs/rudder-sdk-ios",
+        "state": {
+          "branch": null,
+          "revision": "22575f73141aa4192582ee2ade9ae70ee29a6faa",
+          "version": "2.4.3"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -14,14 +14,14 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "AppsFlyerLib", url: "https://github.com/AppsFlyerSDK/AppsFlyerFramework", "6.12.1"..<"6.12.2"),
+        .package(name: "AppsFlyerLib-Static", url: "https://github.com/AppsFlyerSDK/AppsFlyerFramework-Static", "6.14.0"..<"6.14.1"),
         .package(name: "Rudder",url: "https://github.com/rudderlabs/rudder-sdk-ios", from: "2.0.0"),
     ],
     targets: [
         .target(
             name: "RudderAppsFlyer",
             dependencies: [
-                .product(name: "AppsFlyerLib", package: "AppsFlyerLib"),
+                .product(name: "AppsFlyerLib-Static", package: "AppsFlyerLib-Static"),
                 .product(name: "Rudder", package: "Rudder"),
             ],
             path: "Sources",

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
     - AppsFlyerFramework/Main (= 6.14.0)
   - AppsFlyerFramework/Main (6.14.0)
   - Rudder (2.4.3)
-  - RudderAppsFlyer (1.1.1):
+  - RudderAppsFlyer (1.2.0):
     - AppsFlyerFramework (= 6.14.0)
     - Rudder (~> 2.0)
 
@@ -24,7 +24,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AppsFlyerFramework: 84e73360fc5b277da2a9322281c21cc467eaf023
   Rudder: 6d2c0775d5b606e05e00670615ee7f9c0c6d2813
-  RudderAppsFlyer: a54bf5304caf9af7eb7c1ea20daa00ebb1c37c55
+  RudderAppsFlyer: 368ef446b46c5113ef800cdc8b04c1d7b3061481
 
 PODFILE CHECKSUM: 2147a7b1a847ee4029db846e85d4806551834ad3
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - AppsFlyerFramework (6.12.1):
-    - AppsFlyerFramework/Main (= 6.12.1)
-  - AppsFlyerFramework/Main (6.12.1)
-  - Rudder (2.4.1)
-  - RudderAppsFlyer (1.1.0):
-    - AppsFlyerFramework (= 6.12.1)
+  - AppsFlyerFramework (6.14.0):
+    - AppsFlyerFramework/Main (= 6.14.0)
+  - AppsFlyerFramework/Main (6.14.0)
+  - Rudder (2.4.3)
+  - RudderAppsFlyer (1.1.1):
+    - AppsFlyerFramework (= 6.14.0)
     - Rudder (~> 2.0)
 
 DEPENDENCIES:
@@ -22,10 +22,10 @@ EXTERNAL SOURCES:
     :path: "."
 
 SPEC CHECKSUMS:
-  AppsFlyerFramework: e29b63fc5441400a38a31c5501c1da500b9d53d0
-  Rudder: 610bf4deaf3e4dac4fe9abf22fa9dc1b445dc476
-  RudderAppsFlyer: 48681497e80a2f1f03f5465fc32a257cfeb11f75
+  AppsFlyerFramework: 84e73360fc5b277da2a9322281c21cc467eaf023
+  Rudder: 6d2c0775d5b606e05e00670615ee7f9c0c6d2813
+  RudderAppsFlyer: a54bf5304caf9af7eb7c1ea20daa00ebb1c37c55
 
 PODFILE CHECKSUM: 2147a7b1a847ee4029db846e85d4806551834ad3
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.14.3

--- a/README.md
+++ b/README.md
@@ -23,14 +23,15 @@
 </p>
 
 ---
+
 # Integrating RudderStack iOS SDK with AppsFlyer
 
 This repository contains the resources and assets required to integrate the [RudderStack iOS SDK](https://www.rudderstack.com/docs/stream-sources/rudderstack-sdk-integration-guides/rudderstack-ios-sdk/ios-v2/) with [AppsFlyer](https://www.appsflyer.com/).
 
 For more information on configuring AppsFlyer as a destination in RudderStack and the supported events and their mappings, refer to the [AppsFlyer documentation](https://www.rudderstack.com/docs/stream-sources/appsflyer/).
 
-| Important: This device mode integration is supported for AppsFlyer v6.5.4 and above. |
-| :---|
+| Important: This device mode integration is supported for AppsFlyer v6.14.0. |
+| :-------------------------------------------------------------------------- |
 
 ## Step 1: Integrate the SDK with AppsFlyer
 
@@ -38,7 +39,7 @@ For more information on configuring AppsFlyer as a destination in RudderStack an
 2. `RudderAppsFlyer` is available through [CocoaPods](https://cocoapods.org). To install it, add the following line to your `Podfile`:
 
 ```ruby
-pod 'RudderAppsFlyer', '~> 1.1.1'
+pod 'RudderAppsFlyer', '~> 1.2.0'
 ```
 
 3. Run the `pod install` command.
@@ -65,8 +66,8 @@ Place the following in your `AppDelegate` under the `didFinishLaunchingWithOptio
 
 ```swift
 let config: RSConfig = RSConfig(writeKey: WRITE_KEY)
-            .dataPlaneURL(DATA_PLANE_URL)       
-             
+            .dataPlaneURL(DATA_PLANE_URL)
+
 RSClient.sharedInstance().configure(with: config)
 RSClient.sharedInstance().addDestination()
 ```
@@ -90,7 +91,7 @@ Follow the steps listed in the [RudderStack iOS SDK](https://github.com/rudderla
 RudderStack is the **customer data platform** for developers. With RudderStack, you can build and deploy efficient pipelines that collect customer data from every app, website, and SaaS platform, then activate your data in your warehouse, business, and marketing tools.
 
 | Start building a better, warehouse-first CDP that delivers complete, unified data to every part of your customer data stack. Sign up for [RudderStack Cloud](https://app.rudderstack.com/signup?type=freetrial) today. |
-| :---|
+| :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 
 ## Contact us
 

--- a/RudderAppsFlyer.podspec
+++ b/RudderAppsFlyer.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'RudderAppsFlyer'
-    s.version          = '1.1.1'
+    s.version          = '1.2.0'
     s.summary          = 'Privacy and Security focused Segment-alternative. AppsFlyer Native SDK integration support.'
     s.description      = <<-DESC
     Rudder is a platform for collecting, storing and routing customer event data to dozens of tools. Rudder is open-source, can run in your cloud environment (AWS, GCP, Azure or even your data-centre) and provides a powerful transformation framework to process your event data on the fly.

--- a/RudderAppsFlyer.podspec
+++ b/RudderAppsFlyer.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
     s.swift_version = '5.3'
 
     s.dependency 'Rudder', '~> 2.0'
-    s.dependency 'AppsFlyerFramework', '6.12.1'
+    s.dependency 'AppsFlyerFramework', '6.14.0'
 end

--- a/RudderAppsFlyer.xcodeproj/project.pbxproj
+++ b/RudderAppsFlyer.xcodeproj/project.pbxproj
@@ -7,15 +7,15 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		A14198FA391723BCFEA6A46A /* Pods_RudderAppsFlyer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 98626BAB59DD9C92B85299A1 /* Pods_RudderAppsFlyer.framework */; };
 		ED2A28F82770570400646788 /* RudderAppsFlyer.h in Headers */ = {isa = PBXBuildFile; fileRef = ED2A28F72770570400646788 /* RudderAppsFlyer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		ED6AB31D18876EB09C2A0831 /* Pods_RudderAppsFlyer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B7F7171AF4843CEA43A01DB /* Pods_RudderAppsFlyer.framework */; };
 		EDF68FE727D1FD620005AAC6 /* RSAppsFlyerDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDF68FE627D1FD620005AAC6 /* RSAppsFlyerDestination.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		75F66E8CFDC8C7B7976FEE1A /* Pods-RudderAppsFlyer.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderAppsFlyer.release.xcconfig"; path = "Target Support Files/Pods-RudderAppsFlyer/Pods-RudderAppsFlyer.release.xcconfig"; sourceTree = "<group>"; };
-		85B0A4AF78E9A4A4A671EF37 /* Pods-RudderAppsFlyer.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderAppsFlyer.debug.xcconfig"; path = "Target Support Files/Pods-RudderAppsFlyer/Pods-RudderAppsFlyer.debug.xcconfig"; sourceTree = "<group>"; };
-		98626BAB59DD9C92B85299A1 /* Pods_RudderAppsFlyer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RudderAppsFlyer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		76B644ABC86B6F403E136147 /* Pods-RudderAppsFlyer.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderAppsFlyer.debug.xcconfig"; path = "Target Support Files/Pods-RudderAppsFlyer/Pods-RudderAppsFlyer.debug.xcconfig"; sourceTree = "<group>"; };
+		9B7F7171AF4843CEA43A01DB /* Pods_RudderAppsFlyer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RudderAppsFlyer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		ABE0FFA7C6415C35D8CBB54F /* Pods-RudderAppsFlyer.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RudderAppsFlyer.release.xcconfig"; path = "Target Support Files/Pods-RudderAppsFlyer/Pods-RudderAppsFlyer.release.xcconfig"; sourceTree = "<group>"; };
 		ED2A28EB2770560400646788 /* RudderAppsFlyer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RudderAppsFlyer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED2A28F72770570400646788 /* RudderAppsFlyer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RudderAppsFlyer.h; sourceTree = "<group>"; };
 		ED2A28FA2770591E00646788 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
@@ -31,7 +31,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A14198FA391723BCFEA6A46A /* Pods_RudderAppsFlyer.framework in Frameworks */,
+				ED6AB31D18876EB09C2A0831 /* Pods_RudderAppsFlyer.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -41,16 +41,16 @@
 		208F25C796D8593BF8DAB48E /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				85B0A4AF78E9A4A4A671EF37 /* Pods-RudderAppsFlyer.debug.xcconfig */,
-				75F66E8CFDC8C7B7976FEE1A /* Pods-RudderAppsFlyer.release.xcconfig */,
+				76B644ABC86B6F403E136147 /* Pods-RudderAppsFlyer.debug.xcconfig */,
+				ABE0FFA7C6415C35D8CBB54F /* Pods-RudderAppsFlyer.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
 		};
-		5E61559B5F59C6FCEED26EA8 /* Frameworks */ = {
+		C7EFA7D96A8FFBF07FC12D61 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				98626BAB59DD9C92B85299A1 /* Pods_RudderAppsFlyer.framework */,
+				9B7F7171AF4843CEA43A01DB /* Pods_RudderAppsFlyer.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -66,7 +66,7 @@
 				ED2A28F52770570400646788 /* Sources */,
 				ED2A28EC2770560400646788 /* Products */,
 				208F25C796D8593BF8DAB48E /* Pods */,
-				5E61559B5F59C6FCEED26EA8 /* Frameworks */,
+				C7EFA7D96A8FFBF07FC12D61 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -121,7 +121,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = ED2A28F22770560400646788 /* Build configuration list for PBXNativeTarget "RudderAppsFlyer" */;
 			buildPhases = (
-				A4E1A635663682B4E14BD4BC /* [CP] Check Pods Manifest.lock */,
+				B81980160C4EA03E29A2D932 /* [CP] Check Pods Manifest.lock */,
 				ED2A28E62770560400646788 /* Headers */,
 				ED2A28E72770560400646788 /* Sources */,
 				ED2A28E82770560400646788 /* Frameworks */,
@@ -182,7 +182,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		A4E1A635663682B4E14BD4BC /* [CP] Check Pods Manifest.lock */ = {
+		B81980160C4EA03E29A2D932 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -360,7 +360,7 @@
 		};
 		ED2A28F32770560400646788 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 85B0A4AF78E9A4A4A671EF37 /* Pods-RudderAppsFlyer.debug.xcconfig */;
+			baseConfigurationReference = 76B644ABC86B6F403E136147 /* Pods-RudderAppsFlyer.debug.xcconfig */;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
@@ -393,7 +393,7 @@
 		};
 		ED2A28F42770560400646788 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 75F66E8CFDC8C7B7976FEE1A /* Pods-RudderAppsFlyer.release.xcconfig */;
+			baseConfigurationReference = ABE0FFA7C6415C35D8CBB54F /* Pods-RudderAppsFlyer.release.xcconfig */;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;


### PR DESCRIPTION
## Description

- All the RudderAppsFlyer integration versions up to `1.1.1` have this error:
<img width="644" alt="image" src="https://github.com/rudderlabs/rudder-integration-appsflyer-swift/assets/64667840/dfce92a2-e009-45f6-b7fb-c1ac434596b4">

- This issue will occur if someone integrates the integration through SPM and then tries to validate their app in the latest XCode v15.3 (for earlier versions this issue doesn't occur).
- The fix provided by AppsFlyer was to update the SPM link to the static one. Please have a look here for more details: https://github.com/AppsFlyerSDK/AppsFlyerFramework/issues/263#issuecomment-2032421090.
- Bump the AppsFlyer SDK to the latest version 6.14.0 in the PodSpec.
- Bump the AppsFlyer SDK to the latest version 6.14.0 in the SPM.
- Change the codeowner to `@rudderlabs/sdk-ios`.
- Remove `Package.resolved` from `.gitignore` so that its changes are pushed and visible. Previously the changes were visible locally and not pushed.
- Bump the integration version to `1.2.0`.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist:
- [x] Version updated in `README`
- [x] Version updated in `RudderAppsFlyer.xcodeproj`
- [x] Version updated in `RudderAppsFlyer.podspec`
- [x] `CHANGELOG` Updated
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added unit tests for the code
- [ ] I have made corresponding changes to the documentation
- [x] Passed `pod lib lint --no-clean --allow-warnings`
